### PR TITLE
Fix accuracy and timing, remove count down

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Version: $Id:$ $Format:%cd by %aN$
 
 ## Between Runs:
 
-1. When Run #1 is over, press `q` to return to Matlab
-2. Talk to the participant to make sure they are still doing fine, and give them a short break
-3. Ask the participant if they are ready for the next run, which will be another 4 minutes
-4. In the MatLab Command Window, type `y` when asked if you want to proceed to run 2
+1. Talk to the participant to make sure they are still doing fine, and give them a short break
+2. Ask the participant if they are ready for the next run, which will be another 4 minutes
+3. In the MatLab Command Window, type `y` when asked if you want to proceed to run 2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Version: $Id:$ $Format:%cd by %aN$
 
 ## Emergency quit:
 
-- in case of emergency, quit experiment by pressing `q` on your keyboard to quit
+- in case of emergency, quit experiment by typing @ (does not save)
 - if the screen is frozen, type `sca` and then the `return` key
 - If that does not work, press `ctrl-c`. Then `alt+tab` and close the psychtoolbox window
 

--- a/famfloc.m
+++ b/famfloc.m
@@ -69,10 +69,11 @@ task_num = 1;
 
 % which run number to begin executing (default = 1)
 if nargin < 2
-        start_run = [];
-    while isempty(deblank(start_run))
-        start_run = str2num(input('Run : ', 's'));
+    start_run_string = [];
+    while isempty(deblank(start_run_string))
+        start_run_string = input('Run : ', 's');
     end
+    start_run=str2num(start_run_string);
 end
 
 

--- a/functions/fLocSequence.m
+++ b/functions/fLocSequence.m
@@ -16,7 +16,7 @@ classdef fLocSequence
     
     properties (Constant)
 %         stim_conds = {'Bodies' 'Characters' 'Faces' 'Objects' 'Places'}; %lotusea rm
-        stim_conds = {'Bodies' 'Characters' 'Characters' 'Faces' 'Objects' 'Places'}; %lotusea
+        stim_conds = {'Bodies' 'Words' 'Numbers' 'Faces' 'Objects' 'Places'}; %FB
         stim_per_block = 12;   % number of stimuli in a block
         stim_duty_cycle = 0.5; % duration of stimulus duty cycle (s)
     end

--- a/functions/fLocSession.m
+++ b/functions/fLocSession.m
@@ -8,7 +8,6 @@ classdef fLocSession
         sequence  % session fLocSequence object
         responses % behavioral response data structure
         parfiles  % paths to vistasoft-compatible parfiles
-        stim_size = 768;
     end
     
     properties (Hidden)
@@ -21,7 +20,8 @@ classdef fLocSession
     end
     
     properties (Constant)
-        count_down = 12; % pre-experiment countdown (secs)
+        count_down = 0; % pre-experiment countdown (secs) % FB modified from 12 to 0
+        stim_size = 768; % size to display images in pixels
     end
     
     properties (Constant, Hidden)
@@ -30,7 +30,7 @@ classdef fLocSession
         fix_color = [255 0 0]; % fixation marker color (RGB)
         text_color = 255;      % instruction text color (grayscale)
         blank_color = 128;     % baseline screen color (grayscale)
-        wait_dur = 1;          % seconds to wait for response
+        wait_dur = 1.5;          % seconds to wait for response .  %% FB changed from 1 to 1.5 (allowed window for response after repeat)
     end
     
     properties (Dependent)
@@ -195,19 +195,30 @@ classdef fLocSession
                     end
                 end
             end
-            % display countdown numbers
-            [cnt_time, rem_time] = deal(session.count_down + GetSecs);
-            cnt = session.count_down;
-            while rem_time > 0
-                if floor(rem_time) <= cnt
-                    % DrawFormattedText(window_ptr, num2str(cnt), 'center', 'center', tcol);
-                    Screen('Flip', window_ptr);
-                    cnt = cnt - 1;
-                end
-                rem_time = cnt_time - GetSecs;
-            end
+            
+            Screen('FillRect', window_ptr, bcol);
+            draw_fixation(window_ptr, center, fcol);
+            Screen('Flip', window_ptr);
+            
+            start_time = GetSecs; % added by FB, intially at the beginning of the main loop
+            
+            % WaitSecs(10); % 10 s of rest instead of the countdown 
+            % if this is modified, the values in write_parfiles also have
+            % to be
+%             % display countdown numbers %FB cmout
+%             [cnt_time, rem_time] = deal(session.count_down + GetSecs);
+%             cnt = session.count_down;
+%             while rem_time > 0
+%                 if floor(rem_time) <= cnt
+%                     DrawFormattedText(window_ptr, num2str(cnt), 'center', 'center', tcol);
+%                     Screen('Flip', window_ptr);
+%                     cnt = cnt - 1;
+%                 end
+%                 rem_time = cnt_time - GetSecs;
+%             end
+            
             % main display loop
-            start_time = GetSecs;
+            % start_time = GetSecs;
             for ii = 1:length(stim_names)
                 % display blank screen if baseline and image if stimulus
                 if strcmp(stim_names{ii}, 'baseline')
@@ -220,7 +231,7 @@ classdef fLocSession
                 Screen('Flip', window_ptr);
                 % collect responses
                 ii_press = []; ii_keys = [];
-                [keys, ie] = record_keys(start_time + (ii - 1) * sdc, stim_dur, k);
+                [keys, ie] = record_keys(start_time + (ii - 1) * sdc, stim_dur, k); % FB modified record_keys to ignore TTL '5'
                 ii_keys = [ii_keys keys]; ii_press = [ii_press ie];
                 % display ISI if necessary
                 if isi_dur > 0
@@ -231,7 +242,7 @@ classdef fLocSession
                     Screen('Flip', window_ptr);
                 end
                 resp_keys{ii} = ii_keys;
-                resp_press(ii) = min(ii_press);
+                resp_press(ii) = 1-min(ii_press); %FB changed min(ii_press) into 1-min(ii_press) so that resp_press says whether there WAS a response
             end
             % store responses
             session.responses(run_num).keys = resp_keys;
@@ -239,15 +250,27 @@ classdef fLocSession
             fname = [session.id '_backup_run' num2str(run_num) '.mat'];
             fpath = fullfile(session.exp_dir, 'data', session.id, fname);
             save(fpath, 'resp_keys', 'resp_press', '-v7.3');
-            % analyze response data and display performance
+            % analyze response data and display performance (in matlab window rather than Psychtoolbox screen)
             session = score_task(session, run_num);
-            Screen('FillRect', window_ptr, bcol);
-            Screen('Flip', window_ptr);
-            Screen('Flip', window_ptr);
-            get_key('q', session.keyboard);
+            num_probes = num2str(sum(session.sequence.task_probes(:, run_num)));
+            hit_cnt = num2str(session.hit_cnt(run_num));
+            fa_cnt = num2str(session.fa_cnt(run_num));
+            hit_rate = num2str(session.hit_rate(run_num) * 100);
+            hit_str = ['Hits: ' hit_cnt '/' num_probes ' (' hit_rate '%)'];
+            fa_str = ['False alarms: ' fa_cnt];
+%             Screen('FillRect', window_ptr, bcol);
+%             Screen('Flip', window_ptr);
+%             score_str = [hit_str '\n' fa_str];
+%             DrawFormattedText(window_ptr, score_str, 'center', 'center', tcol);
+%             Screen('Flip', window_ptr);
+            disp(hit_str);
+            disp(fa_str);
+            % get_key('g', session.keyboard); % lotusea cmout
+            % get_key('c', session.keyboard); %FB created and cmout
             ShowCursor;
             Screen('CloseAll');
         end
+        
         
         % quantify performance in stimulus task
         function session = score_task(session, run_num)

--- a/functions/fLocSession.m
+++ b/functions/fLocSession.m
@@ -8,6 +8,7 @@ classdef fLocSession
         sequence  % session fLocSequence object
         responses % behavioral response data structure
         parfiles  % paths to vistasoft-compatible parfiles
+        stim_size = 768; % size to display images in pixels % over-ridden below in session.stim_size
     end
     
     properties (Hidden)
@@ -21,7 +22,6 @@ classdef fLocSession
     
     properties (Constant)
         count_down = 0; % pre-experiment countdown (secs) % FB modified from 12 to 0
-        stim_size = 768; % size to display images in pixels
     end
     
     properties (Constant, Hidden)
@@ -155,6 +155,8 @@ classdef fLocSession
             resp_keys = {}; resp_press = zeros(length(stim_names), 1);
             % setup screen and load all stimuli in run
             [window_ptr, center] = do_screen;
+            Screen('FillRect', window_ptr, bcol); % display grey background
+            Screen('Flip', window_ptr);
             center_x = center(1); center_y = center(2); s = session.stim_size / 2;
             stim_rect = [center_x - s center_y - s center_x + s center_y + s];
             img_ptrs = [];
@@ -175,7 +177,9 @@ classdef fLocSession
                 Screen('Flip', window_ptr);
                 get_key('5', session.keyboard);   % lotusea add
                 DrawFormattedText(window_ptr, 'Get Ready!', 'center', 'center', tcol);
-                get_key('5', session.keyboard);   % lotusea add
+                Screen('Flip', window_ptr);
+                WaitSecs(.2); % makes sure manual presses of 5s don't get registered twice
+                get_key('5', session.keyboard);   % dummy TR
 
             elseif session.trigger == 1
                 Screen('FillRect', window_ptr, bcol);
@@ -202,20 +206,19 @@ classdef fLocSession
             
             start_time = GetSecs; % added by FB, intially at the beginning of the main loop
             
-            % WaitSecs(10); % 10 s of rest instead of the countdown 
             % if this is modified, the values in write_parfiles also have
             % to be
-%             % display countdown numbers %FB cmout
-%             [cnt_time, rem_time] = deal(session.count_down + GetSecs);
-%             cnt = session.count_down;
-%             while rem_time > 0
-%                 if floor(rem_time) <= cnt
-%                     DrawFormattedText(window_ptr, num2str(cnt), 'center', 'center', tcol);
-%                     Screen('Flip', window_ptr);
-%                     cnt = cnt - 1;
-%                 end
-%                 rem_time = cnt_time - GetSecs;
-%             end
+            % display countdown numbers %FB cmout
+            [cnt_time, rem_time] = deal(session.count_down + GetSecs);
+            cnt = session.count_down;
+            while rem_time > 0
+                if floor(rem_time) <= cnt
+                    DrawFormattedText(window_ptr, num2str(cnt), 'center', 'center', tcol);
+                    Screen('Flip', window_ptr);
+                    cnt = cnt - 1;
+                end
+                rem_time = cnt_time - GetSecs;
+            end
             
             % main display loop
             % start_time = GetSecs;

--- a/functions/fLocSession.m
+++ b/functions/fLocSession.m
@@ -170,45 +170,47 @@ classdef fLocSession
                 end
             end
             % start experiment triggering scanner if applicable
-            if session.trigger == 0
+%             if session.trigger == 0
                 Screen('FillRect', window_ptr, bcol);
                 Screen('Flip', window_ptr);
                 DrawFormattedText(window_ptr, session.instructions, 'center', 'center', tcol);
                 Screen('Flip', window_ptr);
                 get_key('5', session.keyboard);   % lotusea add
+                start_time = GetSecs; 
+                
+                % add dummy TR
                 DrawFormattedText(window_ptr, 'Get Ready!', 'center', 'center', tcol);
                 Screen('Flip', window_ptr);
                 WaitSecs(.2); % makes sure manual presses of 5s don't get registered twice
-                get_key('5', session.keyboard);   % dummy TR
+                get_key('5', session.keyboard);   
 
-            elseif session.trigger == 1
-                Screen('FillRect', window_ptr, bcol);
-                Screen('Flip', window_ptr);
-                DrawFormattedText(window_ptr, session.instructions, 'center', 'center', tcol); % 'flipHorizontal', 1);
-                Screen('Flip', window_ptr);
-                while 1
-%                     get_key('g', session.keyboard); % lotusea cmout
-                    get_key('5', session.keyboard);  % lotusea add
-                    [status, ~] = start_scan;
-                    if status == 0
-                        break
-                    else
-                        message = 'Trigger failed.';
-                        DrawFormattedText(window_ptr, message, 'center', 'center', fcol);
-                        Screen('Flip', window_ptr);
-                    end
-                end
-            end
+
+%             elseif session.trigger == 1
+%                 Screen('FillRect', window_ptr, bcol);
+%                 Screen('Flip', window_ptr);
+%                 DrawFormattedText(window_ptr, session.instructions, 'center', 'center', tcol); % 'flipHorizontal', 1);
+%                 Screen('Flip', window_ptr);
+%                 while 1
+% %                     get_key('g', session.keyboard); % lotusea cmout
+%                     get_key('5', session.keyboard);  % lotusea add
+%                     [status, ~] = start_scan;
+%                     if status == 0
+%                         break
+%                     else
+%                         message = 'Trigger failed.';
+%                         DrawFormattedText(window_ptr, message, 'center', 'center', fcol);
+%                         Screen('Flip', window_ptr);
+%                     end
+%                 end
+%             end
             
             Screen('FillRect', window_ptr, bcol);
             draw_fixation(window_ptr, center, fcol);
             Screen('Flip', window_ptr);
-            
-            start_time = GetSecs; % added by FB, intially at the beginning of the main loop
-            
+                        
             % if this is modified, the values in write_parfiles also have
             % to be
-            % display countdown numbers %FB cmout
+            % display countdown numbers
             [cnt_time, rem_time] = deal(session.count_down + GetSecs);
             cnt = session.count_down;
             while rem_time > 0

--- a/functions/get_box_num.m
+++ b/functions/get_box_num.m
@@ -14,7 +14,7 @@ for nn = 1:length(d)
     end
 end
 if b == 0
-    fprintf('\nButton box not found.\n');
+    % fprintf('\nButton box not found.\n');
 end
 
 end

--- a/functions/get_keyboard_num.m
+++ b/functions/get_keyboard_num.m
@@ -16,7 +16,7 @@ for nn = 1:length(d)
     end
 end
 if k == 0
-    fprintf('\nKeyboard not found.\n');
+    % fprintf('\nKeyboard not found.\n');
 end
 
 end

--- a/functions/record_keys.m
+++ b/functions/record_keys.m
@@ -2,6 +2,7 @@ function [keys, is_empty] = record_keys(start_time, dur, device_num)
 % Collects all keypresses for a given duration (in secs).
 % Written by KGS Lab
 % Edited by AS 8/2014
+% Edited by FB to ignore TTLs ('5%')
 
 % wait until keys are released
 keys = [];
@@ -14,6 +15,7 @@ end
 % check for pressed keys
 while 1
     [key_is_down, ~, key_code] = KbCheck(device_num);
+    key_code(KbName('5%'))=0; % added by FB to ignore TTL signals
     if key_is_down
         keys = [keys KbName(key_code)];
         while KbCheck(device_num)


### PR DESCRIPTION
- added code to not count '5's / TTLs as button presses
- fix wrong calculation of accuracy
- removed count down time (time 0 = start_time is after the 1st TTL)
- hence .par files timings are actually ok now
- darker more comfortable background while loading
- better labelling of categories in .par files
- response window of 1.5s instead of 1s
- test window closes automatically after run instead of waiting for 'q' press
- remove / fix a few warnings when loading